### PR TITLE
ci-build.yaml Naming Fix

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -3,10 +3,10 @@ name: CI Build
 on:
   push:
     branches:
-      -main
+      - main
   pull_request:
     branches:
-      -main
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Fixed ci-build.yaml naming of main branch by adding a space between "-" and "main" under each branch section.